### PR TITLE
Only hijack the response if the filetype matches what we want to transform

### DIFF
--- a/lib/jsxtransform.js
+++ b/lib/jsxtransform.js
@@ -35,67 +35,72 @@ function getErrorScript(errorMessage) {
 module.exports = function (options) {
 
     return function (req, res, next) {
-        // Prevent If-None-Match revalidation with the downstream middleware with ETags that aren't suffixed with "-jsxtransform":
-        var ifNoneMatch = req.headers['if-none-match'];
-        if (ifNoneMatch) {
-            var validIfNoneMatchTokens = ifNoneMatch.split(' ').filter(function (etag) {
-                return /-jsxtransform\"$/.test(etag);
-            });
-            if (validIfNoneMatchTokens.length > 0) {
-                req.headers['if-none-match'] = validIfNoneMatchTokens.join(' ');
-            } else {
-                delete req.headers['if-none-match'];
-            }
-        }
-        delete req.headers['if-modified-since']; // Prevent false positive conditional GETs after enabling jsxtransform
-        res.hijack(function (err, res) {
-            var fileType = (req.originalUrl.match(/\.(js|jsx)$/) || []).shift();
-            var annotationInserted = false;
-            if (res.statusCode === 200 && fileType) {
-                var chunks = [];
-                res.on('error', function () {
-                    res.unhijack();
-                    next();
-                }).on('data', function (chunk) {
-                    chunks.push(chunk);
-                }).on('end', function () {
-                    if (!chunks.length) {
-                        return res.send(res.statusCode);
-                    }
-                    var jsText = Buffer.concat(chunks).toString('utf-8');
+        var fileType = (req.originalUrl.match(/\.(js|jsx)$/) || []).shift();
 
-                    var firstLine = jsText.split('\n')[0];
-
-                    if (fileType === '.jsx') {
-                        if (!/^\/\*\*(\s)@jsx/.test(firstLine)) {
-                            jsText = '/** @jsx React.DOM */\n' + jsText;
-                            annotationInserted = true;
-                        }
-                    }
-
-                    if (fileType === '.jsx' || /^\/\*\*(\s)@jsx/.test(firstLine)) {
-                        try {
-                            jsText = React.transform(jsText, {});
-
-                            if (annotationInserted) {
-                                jsText = jsText.split('\n').splice(1).join('\n');
-                            }
-                        } catch (e) {
-                            // If parsing the file throws an error, build a
-                            // meaningful error response.
-                            var errorMessage = e.message + '\nIn file: ' + req.originalUrl;
-                            jsText = getErrorScript(errorMessage);
-                        }
-                    }
-
-                    res.setHeader('Content-Type', 'text/javascript');
-                    res.setHeader('Content-Length', Buffer.byteLength(jsText));
-                    res.end(jsText);
+        if (!fileType) {
+            return next();
+        } else {
+            // Prevent If-None-Match revalidation with the downstream middleware with ETags that aren't suffixed with "-jsxtransform":
+            var ifNoneMatch = req.headers['if-none-match'];
+            if (ifNoneMatch) {
+                var validIfNoneMatchTokens = ifNoneMatch.split(' ').filter(function (etag) {
+                    return /-jsxtransform\"$/.test(etag);
                 });
-            } else {
-                res.unhijack(true);
+                if (validIfNoneMatchTokens.length > 0) {
+                    req.headers['if-none-match'] = validIfNoneMatchTokens.join(' ');
+                } else {
+                    delete req.headers['if-none-match'];
+                }
             }
-        });
-        next();
+            delete req.headers['if-modified-since']; // Prevent false positive conditional GETs after enabling jsxtransform
+            res.hijack(function (err, res) {
+                var annotationInserted = false;
+                if (res.statusCode === 200 && fileType) {
+                    var chunks = [];
+                    res.on('error', function () {
+                        res.unhijack();
+                        next();
+                    }).on('data', function (chunk) {
+                        chunks.push(chunk);
+                    }).on('end', function () {
+                        if (!chunks.length) {
+                            return res.send(res.statusCode);
+                        }
+                        var jsText = Buffer.concat(chunks).toString('utf-8');
+
+                        var firstLine = jsText.split('\n')[0];
+
+                        if (fileType === '.jsx') {
+                            if (!/^\/\*\*(\s)@jsx/.test(firstLine)) {
+                                jsText = '/** @jsx React.DOM */\n' + jsText;
+                                annotationInserted = true;
+                            }
+                        }
+
+                        if (fileType === '.jsx' || /^\/\*\*(\s)@jsx/.test(firstLine)) {
+                            try {
+                                jsText = React.transform(jsText, {});
+
+                                if (annotationInserted) {
+                                    jsText = jsText.split('\n').splice(1).join('\n');
+                                }
+                            } catch (e) {
+                                // If parsing the file throws an error, build a
+                                // meaningful error response.
+                                var errorMessage = e.message + '\nIn file: ' + req.originalUrl;
+                                jsText = getErrorScript(errorMessage);
+                            }
+                        }
+
+                        res.setHeader('Content-Type', 'text/javascript');
+                        res.setHeader('Content-Length', Buffer.byteLength(jsText));
+                        res.end(jsText);
+                    });
+                } else {
+                    res.unhijack(true);
+                }
+            });
+            next();
+        }
     };
 };


### PR DESCRIPTION
It seems that the problem in #1 was caused by indiscriminatory hijacking, and specifically unhijacking of requests, which apparently caused the headers to be flushed, meaning no middleware up the chain could do its job any more.

Either this is a bug in hijackresponse or the scaffold we have been using across all these livestyle middlewares. We've just been lucky not to run into this yet because we haven't run with all settings active per default. But that's exactly what I'm doing in the grunt-livestyle wrapper
