### PR TITLE
Propose to use express-interceptor instead of express-hijackresponse

### DIFF
--- a/lib/jsxtransform.js
+++ b/lib/jsxtransform.js
@@ -1,4 +1,4 @@
-require('express-hijackresponse');
+var interceptor = require('express-interceptor');
 
 var React = require('react-tools');
 
@@ -33,74 +33,62 @@ function getErrorScript(errorMessage) {
 }
 
 module.exports = function (options) {
-
-    return function (req, res, next) {
+    return interceptor(function (req, res) {
         var fileType = (req.originalUrl.match(/\.(js|jsx)$/) || []).shift();
+        // Prevent If-None-Match revalidation with the downstream middleware with ETags that aren't suffixed with "-jsxtransform":
+        var ifNoneMatch = req.headers['if-none-match'];
 
-        if (!fileType) {
-            return next();
-        } else {
-            // Prevent If-None-Match revalidation with the downstream middleware with ETags that aren't suffixed with "-jsxtransform":
-            var ifNoneMatch = req.headers['if-none-match'];
-            if (ifNoneMatch) {
-                var validIfNoneMatchTokens = ifNoneMatch.split(' ').filter(function (etag) {
-                    return /-jsxtransform\"$/.test(etag);
-                });
-                if (validIfNoneMatchTokens.length > 0) {
-                    req.headers['if-none-match'] = validIfNoneMatchTokens.join(' ');
-                } else {
-                    delete req.headers['if-none-match'];
+        if (ifNoneMatch) {
+            var validIfNoneMatchTokens = ifNoneMatch.split(' ').filter(function (etag) {
+                return /-jsxtransform\"$/.test(etag);
+            });
+
+            if (validIfNoneMatchTokens.length > 0) {
+                req.headers['if-none-match'] = validIfNoneMatchTokens.join(' ');
+            } else {
+                delete req.headers['if-none-match'];
+            }
+        }
+
+        delete req.headers['if-modified-since']; // Prevent false positive conditional GETs after enabling jsxtransform
+
+        return {
+            isInterceptable: function() {
+                return true;
+            },
+            intercept: function(body, send) {
+                var annotationInserted = false;
+
+                if (res.statusCode === 200) {
+                    var firstLine = body.split('\n')[0];
+
+                    if (fileType === '.jsx') {
+                        if (!/^\/\*\*(\s)@jsx/.test(firstLine)) {
+                            body = '/** @jsx React.DOM */\n' + body;
+                            annotationInserted = true;
+                        }
+                    }
+
+                    if (fileType === '.jsx' || /^\/\*\*(\s)@jsx/.test(firstLine)) {
+                        try {
+                            body = React.transform(body, {});
+
+                            if (annotationInserted) {
+                                body = body.split('\n').splice(1).join('\n');
+                            }
+                        } catch (e) {
+                            // If parsing the file throws an error, build a
+                            // meaningful error response.
+                            var errorMessage = e.message + '\nIn file: ' + req.originalUrl;
+                            body = getErrorScript(errorMessage);
+                        }
+                    }
+
+                    res.setHeader('Content-Type', 'text/javascript');
+                    res.setHeader('Content-Length', Buffer.byteLength(body));
+                    send(body);
                 }
             }
-            delete req.headers['if-modified-since']; // Prevent false positive conditional GETs after enabling jsxtransform
-            res.hijack(function (err, res) {
-                var annotationInserted = false;
-                if (res.statusCode === 200 && fileType) {
-                    var chunks = [];
-                    res.on('error', function () {
-                        res.unhijack();
-                        next();
-                    }).on('data', function (chunk) {
-                        chunks.push(chunk);
-                    }).on('end', function () {
-                        if (!chunks.length) {
-                            return res.send(res.statusCode);
-                        }
-                        var jsText = Buffer.concat(chunks).toString('utf-8');
-
-                        var firstLine = jsText.split('\n')[0];
-
-                        if (fileType === '.jsx') {
-                            if (!/^\/\*\*(\s)@jsx/.test(firstLine)) {
-                                jsText = '/** @jsx React.DOM */\n' + jsText;
-                                annotationInserted = true;
-                            }
-                        }
-
-                        if (fileType === '.jsx' || /^\/\*\*(\s)@jsx/.test(firstLine)) {
-                            try {
-                                jsText = React.transform(jsText, {});
-
-                                if (annotationInserted) {
-                                    jsText = jsText.split('\n').splice(1).join('\n');
-                                }
-                            } catch (e) {
-                                // If parsing the file throws an error, build a
-                                // meaningful error response.
-                                var errorMessage = e.message + '\nIn file: ' + req.originalUrl;
-                                jsText = getErrorScript(errorMessage);
-                            }
-                        }
-
-                        res.setHeader('Content-Type', 'text/javascript');
-                        res.setHeader('Content-Length', Buffer.byteLength(jsText));
-                        res.end(jsText);
-                    });
-                } else {
-                    res.unhijack(true);
-                }
-            });
-            next();
-        }
-    };
+        };
+    });
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "author": "Gustav Nikolaj Olsen <gustavnikolaj@gmail.com>",
   "license": "BSD",
   "dependencies": {
-    "express-hijackresponse": "0.2.1",
+    "express-interceptor": "1.0.0",
     "react-tools": "=0.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello there,

First I'd like to thank you for the awesome module that express-jsxtransform is.

This PR is meant to use another great module called express-interceptor, it allows you to define a previous step before sending a response and do whatever you need with it. Also you can avoid calling next() over and over and overall it helps to have a cleaner base code.
